### PR TITLE
Added Check and Copy for all Files in sysdata to make sure they make …

### DIFF
--- a/src/TestHarness/App.config
+++ b/src/TestHarness/App.config
@@ -5,6 +5,7 @@
   </configSections>
   <appSettings>
     <add key="DefaultConnectionStringName" value="WheelMUDSQLite" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <connectionStrings configSource="Files\connectionstrings.config" />
   <log4net>
@@ -64,7 +65,6 @@
   <runtime>
     <legacyUnhandledExceptionPolicy enabled="1" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      
       <!-- 
         Apparently System.Data.SQLite maintainers delete old versions when they update for NuGet.
         Thus ServiceStack is unable to properly resolve its dependency on 1.0.84.0. This workaround
@@ -73,12 +73,10 @@
         
         For reference: http://stackoverflow.com/questions/13464900/cannot-get-servicestack-ormlite-sqlite64-example-working
       -->
-      
       <dependentAssembly>
         <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
         <bindingRedirect oldVersion="1.0.84.0" newVersion="1.0.86.0" />
       </dependentAssembly>
-      
       <dependentAssembly>
         <assemblyIdentity name="Raven.Abstractions" publicKeyToken="37f41c7f99471593" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.3.0" newVersion="2.0.3.0" />
@@ -92,4 +90,16 @@
   <startup useLegacyV2RuntimeActivationPolicy="true">
     <supportedRuntime version="v4.0" />
   </startup>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/src/TestHarness/TestHarness.csproj
+++ b/src/TestHarness/TestHarness.csproj
@@ -77,9 +77,7 @@
     <FileAlignment>4096</FileAlignment>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
-  </PropertyGroup>
+  <PropertyGroup />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -152,7 +150,6 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="app.manifest" />
     <None Include="mud.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TestHarness/TestHarness.csproj
+++ b/src/TestHarness/TestHarness.csproj
@@ -17,6 +17,13 @@
     </UpgradeBackupLocation>
     <ApplicationIcon>console.ico</ApplicationIcon>
     <IsWebBootstrapper>false</IsWebBootstrapper>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+    <NoStdLib>False</NoStdLib>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <SourceAnalysisOverrideSettingsFile>C:\Users\Hector\AppData\Roaming\ICSharpCode/SharpDevelop4\Settings.SourceAnalysis</SourceAnalysisOverrideSettingsFile>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -31,13 +38,6 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-    <NoStdLib>False</NoStdLib>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <SourceAnalysisOverrideSettingsFile>C:\Users\Hector\AppData\Roaming\ICSharpCode/SharpDevelop4\Settings.SourceAnalysis</SourceAnalysisOverrideSettingsFile>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
@@ -59,6 +59,7 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <BaseAddress>4194304</BaseAddress>
     <FileAlignment>4096</FileAlignment>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>..\..\binRelease\</OutputPath>
@@ -76,8 +77,13 @@
     <FileAlignment>4096</FileAlignment>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="Topshelf, Version=3.1.135.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\packages\Topshelf.3.1.4\lib\net40-full\Topshelf.dll</HintPath>
     </Reference>
@@ -146,6 +152,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="app.manifest" />
     <None Include="mud.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Utilities/Configuration.cs
+++ b/src/Utilities/Configuration.cs
@@ -36,27 +36,6 @@ namespace WheelMUD.Utilities
             return fullPath;
         }
 
-        /// <summary>
-        /// Gets the connection string exe path.
-        /// </summary>
-        /// <returns>A string containing the path to the connectionstrings.exe file.</returns>
-        public static string GetConnectionStringExePath()
-        {
-            string root = GetDataStoragePath();
-
-            return Path.Combine(root, "connectionstrings.exe");
-        }
-
-        /// <summary>
-        /// Gets the connection string file path.
-        /// </summary>
-        /// <returns>A string containing the path to the connectionstrings.exe.config file.</returns>
-        public static string GetConnectionStringFilePath()
-        {
-            string root = GetDataStoragePath();
-
-            return Path.Combine(root, "connectionstrings.config");
-        }
 
         /// <summary>
         /// Gets the connection string configuration file path.
@@ -66,7 +45,7 @@ namespace WheelMUD.Utilities
         {
             string root = GetDataStoragePath();
 
-            return Path.Combine(root, "connectionstrings.exe.config");
+            return Path.Combine(root, "connectionstrings.cfg");
         }
 
         private static string GetMudName()


### PR DESCRIPTION
Windows 10 doesnt allow files with a name ending in ".exe" in ProgramData. Arbitrary but there it is. so creating a empty .exe file to allow loadexemanifest doesnt work and had to be redone.

Also couldnt find anything that copied out the sysdata files when the app is first run. As a result the server blows up on Newbs (me). So I added in a copy method that runs just before the database check runs.

As an addendum looks like VS updated the prk files to 2015
